### PR TITLE
Fix error when getting map value

### DIFF
--- a/composeaddresstranslator.js
+++ b/composeaddresstranslator.js
@@ -7,7 +7,7 @@ util.inherits(ComposeAddressTranslator, cassandra.policies.addressResolution.Add
 
 ComposeAddressTranslator.prototype.translate = function(address, port, callback) {
     origAddress = address + ":" + port;
-    newAddress = ComposeAddressTranslator.address_map[origAddress] || origAddress;
+    newAddress = ComposeAddressTranslator.address_map.get(origAddress) || origAddress;
     callback(newAddress);
 };
 


### PR DESCRIPTION
`ComposeAddressTranslator.address_map[origAddress]` would return `undefined`, resulting in the driving trying to resolve the internal IP of nodes. Using the native `get()` function resolves the issue.